### PR TITLE
Add forceShutdown() method to FakeSmtpRule

### DIFF
--- a/src/main/java/com/github/sleroy/junit/mail/server/test/FakeSmtpRule.java
+++ b/src/main/java/com/github/sleroy/junit/mail/server/test/FakeSmtpRule.java
@@ -126,5 +126,18 @@ public class FakeSmtpRule extends ExternalResource {
 
 	return mailServer.getRelayDomains();
     }
-
+    /**
+     * Forces Shutdown. May be used in cases where you want to test for robustness
+     */
+    public void forceShutdown() {
+    if (mailServer == null) {
+        throw new FakeSmtpRuleException("already closed");
+    }
+    try {
+        mailServer.close();
+        mailServer = null;
+    }catch (Exception e) {
+        throw new FakeSmtpRuleException(e);
+    }
+    }
 }

--- a/src/test/java/com/github/sleroy/junit/mail/server/MailServerTest.java
+++ b/src/test/java/com/github/sleroy/junit/mail/server/MailServerTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,8 +18,9 @@
  */
 package com.github.sleroy.junit.mail.server;
 
-import java.net.UnknownHostException;
-
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,7 +28,6 @@ import com.github.sleroy.fakesmtp.core.ServerConfiguration;
 import com.github.sleroy.fakesmtp.core.exception.BindPortException;
 import com.github.sleroy.fakesmtp.core.exception.InvalidHostException;
 import com.github.sleroy.fakesmtp.core.exception.InvalidPortException;
-import com.github.sleroy.junit.mail.server.MailServer;
 
 public class MailServerTest {
 
@@ -63,19 +63,27 @@ public class MailServerTest {
 
 	@Test(expected = BindPortException.class)
 	public void testStart_BindException() throws Exception {
-		// GIVEN A BASIC CONFIGURATION
-		ServerConfiguration serverConfiguration = new ServerConfiguration();
-		// WHEN I TRIGGER THE SERVER
-		try (MailServer mailServer = new MailServer(serverConfiguration);) {
-			mailServer.start();
-		} finally {
-			//
-		}
-		// THE SERVER IS MISERABILY CRASHING (PORT EXCEPTION ON 25)
-
+		// GIVEN A PORT AND A Running MailServer
+        ServerConfiguration serverConfiguration = new ServerConfiguration().port(2828);
+        try (MailServer mailServer = new MailServer(serverConfiguration)){
+            mailServer.start();
+            // WHEN I TRIGGER THE SERVER
+            startMailServer(serverConfiguration);
+            // THE SERVER IS MISERABILY CRASHING (PORT EXCEPTION ON 2828)
+        } finally {
+            //
+        }
 	}
 
-	/**
+    private void startMailServer(ServerConfiguration serverConfiguration) throws Exception {
+        try (MailServer mailServer = new MailServer(serverConfiguration);) {
+            mailServer.start();
+        } finally {
+            //
+        }
+    }
+
+    /**
 	 * Test start running server.
 	 *
 	 * @throws Exception

--- a/src/test/java/com/github/sleroy/junit/mail/server/MailServerTest.java
+++ b/src/test/java/com/github/sleroy/junit/mail/server/MailServerTest.java
@@ -75,13 +75,13 @@ public class MailServerTest {
         }
 	}
 
-    private void startMailServer(ServerConfiguration serverConfiguration) throws Exception {
+   	private void startMailServer(ServerConfiguration serverConfiguration) throws Exception {
         try (MailServer mailServer = new MailServer(serverConfiguration);) {
             mailServer.start();
         } finally {
             //
         }
-    }
+    	}
 
     /**
 	 * Test start running server.

--- a/src/test/java/com/github/sleroy/junit/mail/server/test/FakeSmtpRuleTest.java
+++ b/src/test/java/com/github/sleroy/junit/mail/server/test/FakeSmtpRuleTest.java
@@ -24,11 +24,16 @@ import org.junit.Test;
 
 import com.github.sleroy.fakesmtp.core.ServerConfiguration;
 import com.github.sleroy.junit.mail.server.test.FakeSmtpRule;
+import org.junit.rules.ErrorCollector;
+import org.junit.rules.ExpectedException;
 
 public class FakeSmtpRuleTest {
 
 	@Rule
 	public FakeSmtpRule smtpServer = new FakeSmtpRule(ServerConfiguration.create().port(2525).charset("UTF-8"));
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	/**
 	 * Tests that the server is launching
@@ -38,4 +43,16 @@ public class FakeSmtpRuleTest {
 		Assert.assertTrue(smtpServer.isRunning());
 	}
 
+	@Test
+	public void forceShutdown() {
+		smtpServer.forceShutdown();
+		Assert.assertFalse(smtpServer.isRunning());
+	}
+	@Test
+	public void forceShutdown_twice_throwsFakeSmtpRuleException() {
+		smtpServer.forceShutdown();
+		Assert.assertFalse(smtpServer.isRunning());
+		thrown.expect(FakeSmtpRuleException.class);
+		smtpServer.forceShutdown();
+	}
 }


### PR DESCRIPTION
This may useful in cases, where you want to check for robustness of you software. This Pull-Request also contains a small refactoring of the BindException-Test which did not work correct on windows.